### PR TITLE
Fix for pyarrow 12

### DIFF
--- a/.github/workflows/download.yml
+++ b/.github/workflows/download.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Install condabadges
         shell: bash

--- a/lib/condabadges/__init__.py
+++ b/lib/condabadges/__init__.py
@@ -66,6 +66,7 @@ def _prev_month_downloads(project: str) -> dict[str: int]:
 
     ddf = dd.read_parquet(
         url,
+        categories=[],
         columns=("counts", "data_source", "pkg_name"),
         storage_options={"anon": True},
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,11 +15,12 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Topic :: Utilities",
 ]
 dependencies = [
     "dask[dataframe]",
-    "pyarrow <12",
+    "pyarrow",
     "pyyaml",
     "requests",
     "s3fs",


### PR DESCRIPTION
Remove pyarrow pin and force `read_parquet` call to assume no columns are categorical.